### PR TITLE
Fixed the 1.3 stuff :) 

### DIFF
--- a/1.3/Defs/AlenRace_AdvancedDroids.xml
+++ b/1.3/Defs/AlenRace_AdvancedDroids.xml
@@ -376,8 +376,6 @@
           <li>Apparel_SmokepopBelt</li>
           <li>Apparel_PsychicShockLance</li>
           <li>Apparel_PsychicInsanityLance</li>
-          <li>Apparel_PackJump</li>
-          <li>Apparel_PackBroadshield</li>
           <li>OrbitalTargeterBombardment</li>
           <li>OrbitalTargeterPowerBeam</li>
         </whiteApparelList>

--- a/1.3/Patches/Patch_Royalty.xml
+++ b/1.3/Patches/Patch_Royalty.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Royalty</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> 
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjBattleDroid"]/alienRace/raceRestriction/whiteApparelList</xpath>
+					<value>
+						<li>Apparel_PackJump</li>
+						<li>Apparel_PackBroadshield</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+
+</Patch>

--- a/Source/AndroidsExpanded/AndroidsExpanded.csproj
+++ b/Source/AndroidsExpanded/AndroidsExpanded.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Androids">
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\1541064015\1.1\Assemblies\Androids.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\workshop\content\294100\1541064015\1.3\Assemblies\Androids.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">

--- a/Source/AndroidsExpanded/Building_DroneCrafter.cs
+++ b/Source/AndroidsExpanded/Building_DroneCrafter.cs
@@ -1,4 +1,5 @@
-﻿using RimWorld;
+﻿using Androids;
+using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
@@ -6,11 +7,10 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
-using Androids;
 
 namespace AndroidsExpanded
 {
-  public class Building_DroneCrafter : Building_PawnCrafter
+    public class Building_DroneCrafter : Building_PawnCrafter
   {
     public bool repeatLastPawn = false;
     private Sustainer soundSustainer;
@@ -30,10 +30,12 @@ namespace AndroidsExpanded
           if (disabled)
             return;
           this.lastDef = def;
-          this.MakePawnAndInitCrafting(def);
-        }), MenuOptionPriority.Default, (Action)null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
+            this.MakePawnAndInitCrafting(def);
+        }),
+        MenuOptionPriority.Default, null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
+        //MenuOptionPriority.Default, (Action)null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
         {
-          Disabled = disabled
+            Disabled = disabled
         });
       }
       if (options.Count <= 0)
@@ -68,16 +70,16 @@ namespace AndroidsExpanded
         case CrafterStatus.Filling:
           if (!this.powerComp.PowerOn || Current.Game.tickManager.TicksGame % 300 != 0)
             break;
-          MoteMaker.ThrowSmoke(this.Position.ToVector3(), this.Map, 1f);
+          FleckMaker.ThrowSmoke(this.Position.ToVector3(), this.Map, 1f);
           break;
         case CrafterStatus.Crafting:
           if (this.powerComp.PowerOn && Current.Game.tickManager.TicksGame % 100 == 0)
           {
             for (int index = 0; index < 5; ++index)
-              MoteMaker.ThrowMicroSparks(this.Position.ToVector3() + new Vector3((float)Rand.Range(-1, 1), 0.0f, (float)Rand.Range(-1, 1)), this.Map);
+              FleckMaker.ThrowMicroSparks(this.Position.ToVector3() + new Vector3((float)Rand.Range(-1, 1), 0.0f, (float)Rand.Range(-1, 1)), this.Map);
             for (int index = 0; index < 3; ++index)
-              MoteMaker.ThrowSmoke(this.Position.ToVector3() + new Vector3(Rand.Range(-1f, 1f), 0.0f, Rand.Range(-1f, 1f)), this.Map, Rand.Range(0.5f, 0.75f));
-            MoteMaker.ThrowHeatGlow(this.Position, this.Map, 1f);
+              FleckMaker.ThrowSmoke(this.Position.ToVector3() + new Vector3(Rand.Range(-1f, 1f), 0.0f, Rand.Range(-1f, 1f)), this.Map, Rand.Range(0.5f, 0.75f));
+            FleckMaker.ThrowHeatGlow(this.Position, this.Map, 1f);
             if (this.soundSustainer == null || this.soundSustainer.Ended)
             {
               SoundDef craftingSound = this.printerProperties.craftingSound;
@@ -132,13 +134,15 @@ namespace AndroidsExpanded
         yield return gizmo;
         gizmo = (Gizmo)null;
       }
-      Command_Toggle commandToggle = new Command_Toggle();
-      commandToggle.defaultLabel = (string)"AndroidGizmoRepeatPawnCraftingLabel".Translate();
-      commandToggle.defaultDesc = (string)"AndroidGizmoRepeatPawnCraftingDescription".Translate();
-      commandToggle.icon = ContentFinder<Texture2D>.Get("ui/designators/PlanOn", true);
-      commandToggle.isActive = (Func<bool>)(() => this.repeatLastPawn);
-      commandToggle.toggleAction = (Action)(() => this.repeatLastPawn = !this.repeatLastPawn);
-      yield return (Gizmo)commandToggle;
+            Command_Toggle commandToggle = new Command_Toggle
+            {
+                defaultLabel = (string)"AndroidGizmoRepeatPawnCraftingLabel".Translate(),
+                defaultDesc = (string)"AndroidGizmoRepeatPawnCraftingDescription".Translate(),
+                icon = ContentFinder<Texture2D>.Get("ui/designators/PlanOn", true),
+                isActive = (Func<bool>)(() => this.repeatLastPawn),
+                toggleAction = (Action)(() => this.repeatLastPawn = !this.repeatLastPawn)
+            };
+            yield return (Gizmo)commandToggle;
     }
   }
 }

--- a/Source/AndroidsExpanded/Building_DroneCrafter.cs
+++ b/Source/AndroidsExpanded/Building_DroneCrafter.cs
@@ -1,5 +1,4 @@
-﻿using Androids;
-using RimWorld;
+﻿using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
@@ -7,10 +6,11 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
+using Androids;
 
 namespace AndroidsExpanded
 {
-    public class Building_DroneCrafter : Building_PawnCrafter
+  public class Building_DroneCrafter : Building_PawnCrafter
   {
     public bool repeatLastPawn = false;
     private Sustainer soundSustainer;
@@ -30,12 +30,10 @@ namespace AndroidsExpanded
           if (disabled)
             return;
           this.lastDef = def;
-            this.MakePawnAndInitCrafting(def);
-        }),
-        MenuOptionPriority.Default, null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
-        //MenuOptionPriority.Default, (Action)null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
+          this.MakePawnAndInitCrafting(def);
+        }), MenuOptionPriority.Default, null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
         {
-            Disabled = disabled
+          Disabled = disabled
         });
       }
       if (options.Count <= 0)
@@ -134,15 +132,13 @@ namespace AndroidsExpanded
         yield return gizmo;
         gizmo = (Gizmo)null;
       }
-            Command_Toggle commandToggle = new Command_Toggle
-            {
-                defaultLabel = (string)"AndroidGizmoRepeatPawnCraftingLabel".Translate(),
-                defaultDesc = (string)"AndroidGizmoRepeatPawnCraftingDescription".Translate(),
-                icon = ContentFinder<Texture2D>.Get("ui/designators/PlanOn", true),
-                isActive = (Func<bool>)(() => this.repeatLastPawn),
-                toggleAction = (Action)(() => this.repeatLastPawn = !this.repeatLastPawn)
-            };
-            yield return (Gizmo)commandToggle;
+      Command_Toggle commandToggle = new Command_Toggle();
+      commandToggle.defaultLabel = (string)"AndroidGizmoRepeatPawnCraftingLabel".Translate();
+      commandToggle.defaultDesc = (string)"AndroidGizmoRepeatPawnCraftingDescription".Translate();
+      commandToggle.icon = ContentFinder<Texture2D>.Get("ui/designators/PlanOn", true);
+      commandToggle.isActive = (Func<bool>)(() => this.repeatLastPawn);
+      commandToggle.toggleAction = (Action)(() => this.repeatLastPawn = !this.repeatLastPawn);
+      yield return (Gizmo)commandToggle;
     }
   }
 }


### PR DESCRIPTION
To fix your errors:
Reference the latest 1.3 androids.dll from the Androids Mod

In Building_DroneCrafter.cs
Change all references of MoteMaker to FleckMaker

And in Building_DroneCrafter.cs replace this:
// Old method calls a System method due to code changes this doesn't work anymore
MenuOptionPriority.Default, (Action)null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)
With ("New //")
// New We get to null it out anyway 
MenuOptionPriority.Default, null, (Thing)null, 0.0f, (Func<Rect, bool>)null, (WorldObject)null)

I went ahead and made an Xpath Patch to check for Royalty.
I removed the two lines throwing the exception on non-royalty enabled games, and added a xml file to the Patches Folder.